### PR TITLE
Update allure commandline download URL; bump allure version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - January 31, 2020
+
+- Updated allure download URL to use official git repository
+- Bump allure default version to 2.13.1
+
 ## [0.1.1] - 03-01-2019
 ### Fixed
 

--- a/orb.yml
+++ b/orb.yml
@@ -7,11 +7,11 @@ commands:
       version:
         description: Allure version to use
         type: string
-        default: 2.8.1
+        default: 2.13.1
     steps:
       - run:
           name: Allure archive download
-          command: curl -L https://dl.bintray.com/qameta/maven/io/qameta/allure/allure-commandline/<< parameters.version >>/allure-commandline-<< parameters.version >>.zip -o /tmp/allure.zip
+          command: curl -L https://github.com/allure-framework/allure2/releases/download/<< parameters.version >>/allure-commandline-<< parameters.version >>.zip -o /tmp/allure.zip
       - run:
           name: Archive extraction
           command: unzip /tmp/allure.zip


### PR DESCRIPTION
This PR uses github's download URL at the main allure repo to download the zip file.

It also bumps the minor version of allure.